### PR TITLE
Fix version mismatch in generated package.json for compatibility

### DIFF
--- a/.changeset/frank-geckos-happen.md
+++ b/.changeset/frank-geckos-happen.md
@@ -1,0 +1,5 @@
+---
+'create-nextrush': patch
+---
+
+version mismatch fix. The generated `package.json` should use `^3.0.0` for `nextrush` and related packages, not the exact version from `constants.js`. This allows users to get compatible updates without being locked to a specific version.

--- a/packages/create-nextrush/src/__tests__/generator.test.ts
+++ b/packages/create-nextrush/src/__tests__/generator.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it } from 'vitest';
 
-import { NEXTRUSH_VERSION } from '../constants.js';
 import { generateProject } from '../generator.js';
 import type { ProjectOptions } from '../types.js';
 
@@ -155,7 +154,7 @@ describe('generateProject', () => {
     it('uses simple PORT declaration in entrypoint', () => {
       const files = generateProject(createOptions({ style: 'functional' }));
       const entry = files.get('src/index.ts')!;
-      expect(entry).toContain("const PORT = Number(process.env.PORT) || 3000;");
+      expect(entry).toContain('const PORT = Number(process.env.PORT) || 3000;');
       expect(entry).toContain('await listen(app, PORT);');
     });
 
@@ -195,7 +194,7 @@ describe('generateProject', () => {
     it('uses simple PORT declaration in class-based entrypoint', () => {
       const files = generateProject(createOptions({ style: 'class-based' }));
       const entry = files.get('src/index.ts')!;
-      expect(entry).toContain("const PORT = Number(process.env.PORT) || 3000;");
+      expect(entry).toContain('const PORT = Number(process.env.PORT) || 3000;');
       expect(entry).toContain('await listen(app, PORT);');
     });
 
@@ -286,7 +285,7 @@ describe('generateProject', () => {
     it('entrypoint uses simple PORT declaration', () => {
       const files = generateProject(createOptions({ style: 'full' }));
       const entry = files.get('src/index.ts')!;
-      expect(entry).toContain("const PORT = Number(process.env.PORT) || 3000;");
+      expect(entry).toContain('const PORT = Number(process.env.PORT) || 3000;');
     });
 
     it('uses awaited controllersPlugin with runtime-safe discovery config in full template', () => {
@@ -368,7 +367,7 @@ describe('generateProject', () => {
       expect(pkg.scripts.dev).toBe(
         'deno run --watch --allow-net --allow-read --allow-env --unstable-sloppy-imports src/index.ts'
       );
-      expect(pkg.scripts.build).toBe(`deno run -A npm:@nextrush/dev@${NEXTRUSH_VERSION} build`);
+      expect(pkg.scripts.build).toBe('deno run -A npm:@nextrush/dev@latest build');
       expect(pkg.scripts.start).toBe('deno run --allow-net --allow-read --allow-env dist/index.js');
     });
   });

--- a/packages/create-nextrush/src/constants.ts
+++ b/packages/create-nextrush/src/constants.ts
@@ -1,8 +1,13 @@
 import type { MiddlewarePreset, Runtime, Style } from './types.js';
 
-// Version injected at build time via tsup define
+// Build-time injected (see tsup.config.ts define) — only for CLI display.
+// All @nextrush/* deps use '^3.0.0' range, compatible across the entire 3.x line.
+// Independent packages bump independently via changesets — ^3.0.0 always resolves the latest.
 declare const __VERSION__: string;
 export const NEXTRUSH_VERSION: string = typeof __VERSION__ !== 'undefined' ? __VERSION__ : '0.0.0';
+
+/** Semver range for all @nextrush/* packages. ^3.0.0 = any 3.x (latest compatible). */
+export const RANGE = '^3.0.0';
 
 export const STYLES: readonly Style[] = ['functional', 'class-based', 'full'];
 export const RUNTIMES: readonly Runtime[] = ['node', 'bun', 'deno'];
@@ -16,17 +21,17 @@ export const DEFAULT_MIDDLEWARE: MiddlewarePreset = 'api';
 export const MIDDLEWARE_PACKAGES: Record<MiddlewarePreset, Record<string, string>> = {
   minimal: {},
   api: {
-    '@nextrush/cors': `^${NEXTRUSH_VERSION}`,
-    '@nextrush/body-parser': `^${NEXTRUSH_VERSION}`,
-    '@nextrush/helmet': `^${NEXTRUSH_VERSION}`,
+    '@nextrush/cors': RANGE,
+    '@nextrush/body-parser': RANGE,
+    '@nextrush/helmet': RANGE,
   },
   full: {
-    '@nextrush/cors': `^${NEXTRUSH_VERSION}`,
-    '@nextrush/body-parser': `^${NEXTRUSH_VERSION}`,
-    '@nextrush/helmet': `^${NEXTRUSH_VERSION}`,
-    '@nextrush/rate-limit': `^${NEXTRUSH_VERSION}`,
-    '@nextrush/compression': `^${NEXTRUSH_VERSION}`,
-    '@nextrush/request-id': `^${NEXTRUSH_VERSION}`,
+    '@nextrush/cors': RANGE,
+    '@nextrush/body-parser': RANGE,
+    '@nextrush/helmet': RANGE,
+    '@nextrush/rate-limit': RANGE,
+    '@nextrush/compression': RANGE,
+    '@nextrush/request-id': RANGE,
   },
 };
 
@@ -65,8 +70,8 @@ export const MIDDLEWARE_SETUP: Record<MiddlewarePreset, string> = {
 /** Adapter packages for non-Node runtimes. */
 export const ADAPTER_PACKAGES: Record<Runtime, Record<string, string>> = {
   node: {},
-  bun: { '@nextrush/adapter-bun': `^${NEXTRUSH_VERSION}` },
-  deno: { '@nextrush/adapter-deno': `^${NEXTRUSH_VERSION}` },
+  bun: { '@nextrush/adapter-bun': RANGE },
+  deno: { '@nextrush/adapter-deno': RANGE },
 };
 
 /** Valid npm package name pattern. */

--- a/packages/create-nextrush/src/templates/shared.ts
+++ b/packages/create-nextrush/src/templates/shared.ts
@@ -1,4 +1,4 @@
-import { ADAPTER_PACKAGES, MIDDLEWARE_PACKAGES, NEXTRUSH_VERSION } from '../constants.js';
+import { ADAPTER_PACKAGES, MIDDLEWARE_PACKAGES, RANGE } from '../constants.js';
 import type { DependencySet, ProjectOptions, Runtime } from '../types.js';
 
 /** Generates tsconfig.json content for a new project. */
@@ -53,7 +53,7 @@ export function generatePackageJson(options: ProjectOptions): string {
 /** Resolves the dependency sets for a project configuration. */
 export function getDependencies(options: ProjectOptions): DependencySet {
   const dependencies: Record<string, string> = {
-    nextrush: `^${NEXTRUSH_VERSION}`,
+    nextrush: RANGE,
   };
 
   const needsReflectMetadata = options.style === 'class-based' || options.style === 'full';
@@ -73,8 +73,8 @@ export function getDependencies(options: ProjectOptions): DependencySet {
   Object.assign(dependencies, adapterDeps);
 
   const devDependencies: Record<string, string> = {
-    '@nextrush/dev': `^${NEXTRUSH_VERSION}`,
-    '@nextrush/types': `^${NEXTRUSH_VERSION}`,
+    '@nextrush/dev': RANGE,
+    '@nextrush/types': RANGE,
     typescript: '^6.0.2',
   };
 
@@ -179,7 +179,7 @@ export function getRuntimeEntrypointImports(
 /** Returns the PORT declaration line for the given runtime. */
 export function getPortDeclaration(runtime: Runtime): string {
   if (runtime === 'deno') {
-    return 'const PORT = Number(Deno.env.get(\'PORT\')) || 3000;';
+    return "const PORT = Number(Deno.env.get('PORT')) || 3000;";
   }
   return 'const PORT = Number(process.env.PORT) || 3000;';
 }
@@ -207,7 +207,7 @@ function getRuntimeScripts(runtime: Runtime): {
     case 'deno':
       return {
         dev: 'deno run --watch --allow-net --allow-read --allow-env --unstable-sloppy-imports src/index.ts',
-        build: `deno run -A npm:@nextrush/dev@${NEXTRUSH_VERSION} build`,
+        build: 'deno run -A npm:@nextrush/dev@latest build',
         start: 'deno run --allow-net --allow-read --allow-env dist/index.js',
       };
     case 'node':

--- a/packages/create-nextrush/tsup.config.ts
+++ b/packages/create-nextrush/tsup.config.ts
@@ -1,6 +1,6 @@
 import { readFileSync } from 'node:fs';
-import { fileURLToPath } from 'node:url';
 import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { defineConfig } from 'tsup';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -16,6 +16,7 @@ export default defineConfig({
   sourcemap: true,
   splitting: false,
   define: {
+    // Only used for CLI version display (create-nextrush vX.Y.Z)
     __VERSION__: JSON.stringify(pkg.version),
   },
 });


### PR DESCRIPTION
- Update package.json to use '^3.0.0' for nextrush and related packages.
- Ensure generated files reflect the correct dependency range for updates.
- Adjust tests to maintain consistency with new version handling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed version mismatch in generated projects by updating dependency version handling to use a flexible semver range (`^3.0.0`) instead of exact version pinning, improving compatibility with package resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->