### PR TITLE
fix(docs): build-time OpenAPI generation

### DIFF
--- a/.changeset/openapi-exports-default.md
+++ b/.changeset/openapi-exports-default.md
@@ -1,0 +1,10 @@
+---
+"@nextrush/openapi": patch
+---
+
+Add a `default` condition to the package's `exports` map so CJS-resolving tools
+(e.g. `tsx` running the docs site's `generate-openapi.ts`) can import the package.
+The docs website now declares `@nextrush/openapi` (and `@nextrush/types`, type-only
+imports) as workspace devDependencies and imports by package specifier instead of a
+relative `dist/` path — this also gives turbo the dependency edge it needs to build
+them before the website build.

--- a/apps/website/package.json
+++ b/apps/website/package.json
@@ -35,6 +35,8 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
+    "@nextrush/openapi": "workspace:*",
+    "@nextrush/types": "workspace:*",
     "@playwright/test": "^1.62.0",
     "@tailwindcss/postcss": "^4.3.3",
     "@types/mdx": "^2.0.14",

--- a/apps/website/scripts/generate-openapi.ts
+++ b/apps/website/scripts/generate-openapi.ts
@@ -18,8 +18,8 @@
 import { mkdirSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import type { RouteDefinition, StandardSchemaV1 } from '../../../packages/types/dist/index.js';
-import { generateDocument } from '../../../packages/middleware/openapi/dist/index.js';
+import type { RouteDefinition, StandardSchemaV1 } from '@nextrush/types';
+import { generateDocument } from '@nextrush/openapi';
 import { z } from 'zod';
 
 const here = path.dirname(fileURLToPath(import.meta.url));

--- a/packages/middleware/openapi/package.json
+++ b/packages/middleware/openapi/package.json
@@ -9,7 +9,8 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
     }
   },
   "files": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -220,6 +220,12 @@ importers:
         specifier: ^4.4.3
         version: 4.4.3
     devDependencies:
+      '@nextrush/openapi':
+        specifier: workspace:*
+        version: link:../../packages/middleware/openapi
+      '@nextrush/types':
+        specifier: workspace:*
+        version: link:../../packages/types
       '@playwright/test':
         specifier: ^1.62.0
         version: 1.62.0


### PR DESCRIPTION
- generate-openapi.ts imports @nextrush/openapi by package specifier (was relative dist/ path)
- openapi adds `default` exports condition (tsx/CJS resolution)
- website declares @nextrush/openapi + @nextrush/types as workspace devDeps (turbo build order)
- changeset: @nextrush/openapi patch (types untouched — fixed group stays 4.0.0)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved package compatibility for tools using CommonJS-style module resolution.
  * Updated the website’s OpenAPI generation workflow to use workspace packages directly.
* **Build & Tooling**
  * Improved build ordering and package integration for the documentation website.
  * Added workspace development dependencies for OpenAPI and type definitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->