### PR TITLE
feat: class-based feature-module scaffold, functional todos CRUD, and dev generator alignment

### DIFF
--- a/.changeset/tidy-lions-create-nextrush.md
+++ b/.changeset/tidy-lions-create-nextrush.md
@@ -1,0 +1,7 @@
+---
+"create-nextrush": minor
+---
+
+feat(class-based): proper feature-module scaffold — root `AppModule` composes feature modules via `@Module({ imports })` under `src/modules/<feature>/`; health + todos features demonstrate constructor DI, full CRUD decorators (`@Param`/`@Body`/`@Query`/`@HttpCode`), `@Repository`, and `HttpError` paths.
+
+feat(functional): todos CRUD feature — `src/routes/todos.ts` handlers using `ctx.params`/`ctx.query`/`ctx.body`/`ctx.status`/`ctx.throw`, backed by a pure `createTodoStore()` factory (`src/routes/todos-data.ts`) with unit tests.

--- a/.changeset/tidy-lions-generate.md
+++ b/.changeset/tidy-lions-generate.md
@@ -1,0 +1,5 @@
+---
+"@nextrush/dev": minor
+---
+
+feat(generate): align generators with the create-nextrush scaffolds — new `module` generator type, module-aware placement for controllers/services, DI-connected controller and HttpError service templates, named-export route template. Fix `rootDir` in tsconfig for TS 6 typecheck.

--- a/apps/website/content/docs/guides/api-development/generators.mdx
+++ b/apps/website/content/docs/guides/api-development/generators.mdx
@@ -1,10 +1,10 @@
 ---
 title: Code Generators
-description: Scaffold controllers, services, middleware, guards, and routes from the command line
+description: Scaffold modules, controllers, services, middleware, guards, and routes from the command line
 keywords: [api, code, development, generators, guides, nextrush]
 ---
 
-The `nextrush generate` command (alias `nextrush g`) creates new files from templates with the correct structure, imports, and naming conventions.
+The `nextrush generate` command (alias `nextrush g`) creates new files from templates with the correct structure, imports, and naming conventions — matching the layouts the `create-nextrush` scaffolds emit.
 
 ## Usage
 
@@ -18,13 +18,17 @@ nextrush g <type> <name>
 <TypeTable
   title="Available generators"
   types={{
+    'module (m)': {
+      type: 'string',
+      description: 'Class-based feature module with @Module, controllers, and providers',
+    },
     'controller (c)': {
       type: 'string',
-      description: 'Class-based controller with @Controller, @Get, @Post, @Param, @Body decorators',
+      description: 'Class-based controller with @Controller, @Get, @Post, @Param, @Body, constructor DI',
     },
     'service (s)': {
       type: 'string',
-      description: 'Injectable service class with @Service decorator and CRUD stubs',
+      description: 'Injectable service class with @Service decorator and HttpError paths',
     },
     'middleware (mw)': {
       type: 'string',
@@ -36,12 +40,44 @@ nextrush g <type> <name>
     },
     'route (r)': {
       type: 'string',
-      description: 'Functional router with GET, GET/:id, and POST routes',
+      description: 'Functional router (named export) with GET, GET/:id, and POST routes',
     },
   }}
 />
 
 ## Examples
+
+### Generate a Module
+
+```bash
+nextrush g module todos
+```
+
+Creates `src/modules/todos/todos.module.ts`:
+
+```typescript title="src/modules/todos/todos.module.ts"
+import { Module } from 'nextrush/class';
+
+import { TodosController } from './todos.controller.js';
+import { TodosService } from './todos.service.js';
+
+@Module({
+  controllers: [TodosController],
+  providers: [TodosService],
+})
+export class TodosModule {}
+```
+
+A feature module composes its controller and service. Generate all three for a complete
+feature:
+
+```bash
+nextrush g m todos
+nextrush g controller todos
+nextrush g service todos
+```
+
+Then register the module in your root module's `imports`.
 
 ### Generate a Controller
 
@@ -49,26 +85,31 @@ nextrush g <type> <name>
 nextrush g controller user
 ```
 
-Creates `src/controllers/user.controller.ts`:
+In a class-based project (one with a `src/modules/` directory) the controller is placed
+inside its feature module: `src/modules/user/user.controller.ts`. In a module-less project
+it lands at `src/controllers/user.controller.ts`.
 
-```typescript title="src/controllers/user.controller.ts"
-import { Controller, Get, Post, Body, Param } from 'nextrush/class';
+```typescript title="src/modules/user/user.controller.ts"
+import { Body, Controller, Get, Param, Post } from 'nextrush/class';
+import { UserService } from './user.service.js';
 
 @Controller('/user')
 export class UserController {
+  constructor(private readonly userService: UserService) {}
+
   @Get()
-  async findAll() {
-    return [];
+  findAll() {
+    return this.userService.findAll();
   }
 
   @Get('/:id')
-  async findOne(@Param('id') id: string) {
-    return { id };
+  findOne(@Param('id') id: string) {
+    return this.userService.findOne(id);
   }
 
   @Post()
-  async create(@Body() data: unknown) {
-    return data;
+  create(@Body() data: unknown) {
+    return this.userService.create(data);
   }
 }
 ```
@@ -79,22 +120,26 @@ export class UserController {
 nextrush g service user
 ```
 
-Creates `src/services/user.service.ts`:
+Creates `src/modules/user/user.service.ts` in a module project, or
+`src/services/user.service.ts` otherwise:
 
-```typescript title="src/services/user.service.ts"
+```typescript title="src/modules/user/user.service.ts"
+import { HttpError } from 'nextrush';
 import { Service } from 'nextrush/class';
 
 @Service()
 export class UserService {
-  async findAll() {
+  findAll() {
     return [];
   }
 
-  async findOne(id: string) {
+  findOne(id: string) {
+    if (!id) throw new HttpError(404, 'Not found');
     return { id };
   }
 
-  async create(data: unknown) {
+  create(data: unknown) {
+    if (!data || typeof data !== 'object') throw new HttpError(400, 'Invalid input');
     return data;
   }
 }
@@ -144,38 +189,43 @@ export const authGuard: GuardFn = async (ctx) => {
 nextrush g route product
 ```
 
-Creates `src/routes/product.ts`:
+Creates `src/routes/product.ts` — a named-export router, matching the functional
+template's mounting idiom (`import { productRouter } from './routes/product.js'` +
+`app.route('/product', productRouter)`):
 
 ```typescript title="src/routes/product.ts"
 import { createRouter } from 'nextrush';
 
-const router = createRouter();
+export const productRouter = createRouter();
 
-router.get('/', (ctx) => {
+productRouter.get('/', (ctx) => {
   ctx.json([]);
 });
 
-router.get('/:id', (ctx) => {
+productRouter.get('/:id', (ctx) => {
   ctx.json({ id: ctx.params.id });
 });
 
-router.post('/', (ctx) => {
+productRouter.post('/', (ctx) => {
+  ctx.status = 201;
   ctx.json(ctx.body);
 });
-
-export default router;
 ```
 
 ## Output Directories
 
-| Type       | Output Directory   | File Suffix      |
-| ---------- | ------------------ | ---------------- |
-| controller | `src/controllers/` | `.controller.ts` |
-| service    | `src/services/`    | `.service.ts`    |
-| middleware | `src/middleware/`  | `.ts`            |
-| guard      | `src/guards/`      | `.guard.ts`      |
-| route      | `src/routes/`      | `.ts`            |
+| Type       | Default Directory      | Module project (`src/modules/` exists) | File Suffix      |
+| ---------- | ---------------------- | -------------------------------------- | ---------------- |
+| module     | `src/modules/<name>/`  | `src/modules/<name>/`                  | `.module.ts`     |
+| controller | `src/controllers/`     | `src/modules/<name>/`                  | `.controller.ts` |
+| service    | `src/services/`        | `src/modules/<name>/`                  | `.service.ts`    |
+| middleware | `src/middleware/`      | `src/middleware/`                      | `.ts`            |
+| guard      | `src/guards/`          | `src/guards/`                          | `.guard.ts`      |
+| route      | `src/routes/`          | `src/routes/`                          | `.ts`            |
 
+In a class-based project (one with a `src/modules/` directory), controllers and services
+co-locate inside their feature module so the module, controller, service, and tests live
+together. In module-less (functional/full) projects they use the flat directories above.
 Directories are created automatically if they don't exist.
 
 ## Naming Convention
@@ -187,6 +237,12 @@ Names must be lowercase with optional hyphens. The generator converts them to Pa
 | `user`         | `UserController`        | `user`        |
 | `user-profile` | `UserProfileController` | `userProfile` |
 | `auth`         | `AuthController`        | `authGuard`   |
+
+<Callout type="info" title="Wiring generated files">
+  Generators create files; they do not edit existing source. Add generated modules to
+  your root module's `imports`, mount generated routes with `app.route(...)`, and register
+  guards/middleware where they apply.
+</Callout>
 
 <Callout type="warn" title="Existing Files">
   The generator will not overwrite existing files. If the target file already exists, the command

--- a/packages/create-nextrush/ARCHITECTURE.md
+++ b/packages/create-nextrush/ARCHITECTURE.md
@@ -261,13 +261,25 @@ src/
 ```text
 src/
 ├── index.ts
-├── controllers/
-│   └── health.controller.ts
-└── services/
-    ├── app.service.ts
-    └── __tests__/
-        └── app.service.test.ts
+├── app.module.ts
+└── modules/
+    ├── health/
+    │   ├── health.module.ts
+    │   ├── health.controller.ts
+    │   └── health.service.ts
+    └── todos/
+        ├── todos.module.ts
+        ├── todos.controller.ts
+        ├── todos.service.ts
+        ├── todos.repository.ts
+        └── __tests__/
+            ├── todos.service.test.ts
+            └── todos.controller.test.ts
 ```
+
+Feature modules live under `src/modules/<feature>/`, co-locating each module's
+controller, service, repository, and tests. The root `AppModule` composes them via
+`@Module({ imports: [...] })`; `registerModule` resolves the whole graph at boot.
 
 **`full`** (`templates/full.ts`):
 
@@ -290,7 +302,7 @@ All three styles additionally get `tsconfig.json`, `package.json`, `src/env.d.ts
 `.gitignore`, and `README.md` from `generator.ts`'s shared step. No style emits a
 `not-found.ts` or any other 404-handler file — there is no such generator function in
 `templates/`. The health payload built by `functional`'s `health-status.ts` and
-`class-based`'s `app.service.ts` both include a real `uptime: process.uptime()` field
+`class-based`'s `health.service.ts` both include a real `uptime: process.uptime()` field
 alongside `status` and `timestamp` — confirmed directly in `templates/functional.ts` and
 `templates/class-based.ts`.
 

--- a/packages/create-nextrush/ARCHITECTURE.md
+++ b/packages/create-nextrush/ARCHITECTURE.md
@@ -252,9 +252,18 @@ src/
 └── routes/
     ├── health.ts
     ├── health-status.ts
+    ├── todos.ts
+    ├── todos-data.ts
     └── __tests__/
-        └── health-status.test.ts
+        ├── health-status.test.ts
+        └── todos-data.test.ts
 ```
+
+Two features teach the functional idiom: a minimal health check (route +
+pure payload builder) and a todos CRUD feature (route handlers using
+`ctx.params`/`ctx.query`/`ctx.body`, `ctx.status`, `ctx.throw`, backed by a
+pure `createTodoStore()` factory — state stays per-instance, no global
+mutable state, fully unit-testable without an HTTP server).
 
 **`class-based`** (`templates/class-based.ts`):
 

--- a/packages/create-nextrush/README.md
+++ b/packages/create-nextrush/README.md
@@ -156,11 +156,19 @@ unit-testable payload builder), and its test.
 ### Scaffold a class-based project with DI
 
 ```bash
-pnpm create nextrush my-api --style class-based --middleware minimal --yes
+pnpm create nextrush my-api --style class-based --middleware api --yes
 ```
 
-Generates `src/index.ts` (which calls `registerControllers` under prefix `/api`),
-`src/controllers/health.controller.ts`, `src/services/app.service.ts`, and its test.
+Generates a feature-module scaffold: `src/index.ts` (which calls `registerModule(app,
+AppModule)` under prefix `/api`), a root `src/app.module.ts` composing feature modules via
+`@Module({ imports })`, and two feature modules under `src/modules/`:
+
+- `health/` — minimal controller + service with constructor DI.
+- `todos/` — full CRUD (`@Get`/`@Post`/`@Delete` with `@Param`/`@Body`/`@Query`,
+  `@HttpCode`, `@Repository`, `HttpError` validation paths) plus unit tests.
+
+Use `--middleware minimal` to omit the body-parser/cors/helmet presets; note `@Body()`
+requires a body-parser (`app.use(json())`), which ships with the default `api` preset.
 
 ### Target Bun or Deno instead of Node
 

--- a/packages/create-nextrush/README.md
+++ b/packages/create-nextrush/README.md
@@ -151,7 +151,9 @@ pnpm create nextrush my-api --style functional --middleware api --yes
 ```
 
 Generates `src/index.ts`, `src/routes/health.ts`, `src/routes/health-status.ts` (the pure,
-unit-testable payload builder), and its test.
+unit-testable payload builder), a full todos CRUD feature (`src/routes/todos.ts` backed by
+the pure `src/routes/todos-data.ts` store — params, query, body, response codes, 400/404
+error paths), and unit tests for both pure modules.
 
 ### Scaffold a class-based project with DI
 

--- a/packages/create-nextrush/src/__tests__/controller-discovery-scope.test.ts
+++ b/packages/create-nextrush/src/__tests__/controller-discovery-scope.test.ts
@@ -10,6 +10,9 @@ import { seedAllPackageVersions } from './test-helpers.js';
  * Asserts controller auto-discovery is scoped to the controllers directory
  * (`root: './src/controllers'`), not the whole `src` tree — so discovery never imports
  * non-controller files (routes, services) or the entry module itself.
+ *
+ * Only the `full` template uses filesystem discovery: the class-based template composes
+ * controllers explicitly via `@Module`/`registerModule` (no discovery scope to constrain).
  */
 function createOptions(overrides: Partial<ProjectOptions>): ProjectOptions {
   return {
@@ -25,7 +28,7 @@ function createOptions(overrides: Partial<ProjectOptions>): ProjectOptions {
   };
 }
 
-const STYLES_WITH_CONTROLLERS: readonly Style[] = ['class-based', 'full'];
+const STYLES_WITH_CONTROLLERS: readonly Style[] = ['full'];
 
 describe('controller auto-discovery is scoped to the controllers directory (task 6.1)', () => {
   for (const style of STYLES_WITH_CONTROLLERS) {

--- a/packages/create-nextrush/src/__tests__/cross-runtime-parity-smoke.test.ts
+++ b/packages/create-nextrush/src/__tests__/cross-runtime-parity-smoke.test.ts
@@ -19,6 +19,11 @@ import { seedAllPackageVersions } from './test-helpers.js';
  * the same response body/status from `/health` on Node (always available in this suite);
  * Bun/Deno boot parity is covered by the generate-then-install CI matrix (task 2.1/7.3),
  * which runs a real install against publish versions on every runtime present in CI.
+ *
+ * The child is spawned through `@nextrush/dev`'s swc-loader (`--import`) — the same
+ * mechanism the `nextrush dev` toolchain uses to run TypeScript — so the generated
+ * project boots exactly as emitted (relative `.js` specifiers resolve back to `.ts`).
+ * CI builds the fixture's workspace deps (incl. `@nextrush/dev`) before this suite runs.
  */
 
 const __filename = fileURLToPath(import.meta.url);
@@ -29,6 +34,7 @@ const WORKSPACE_ROOT = resolve(__dirname, '../../../../');
 // root's, so this fixture's already-resolved node_modules is what a generated project's
 // symlinked-in dependency graph should mirror.
 const FIXTURE_NODE_MODULES = join(WORKSPACE_ROOT, 'examples', 'dev-cli-fixture', 'node_modules');
+const SWC_LOADER = join(WORKSPACE_ROOT, 'packages', 'dev', 'dist', 'loaders', 'swc-loader.mjs');
 
 function createOptions(): ProjectOptions {
   return {
@@ -75,27 +81,10 @@ describe('cross-runtime parity: functional /health response (task 4.4)', () => {
       symlinkSync(FIXTURE_NODE_MODULES, join(projectDir, 'node_modules'), 'dir');
 
       const port = 39000 + Math.floor(Math.random() * 500);
-      // `--experimental-strip-types` is Node's raw type-stripper (not the real `nextrush
-      // dev` toolchain, which resolves relative `.js` specifiers back to `.ts` via
-      // @swc-node/register) — inline the health route here so this smoke test proves the
-      // boot + response contract without depending on that resolution step, which is
-      // @nextrush/dev's own concern (dev-tooling capability), not this scaffolder's output.
-      const entrySource = files
-        .get('src/index.ts')!
-        .replace('|| 8080', `|| ${port}`)
-        .replace(
-          "import { healthRouter } from './routes/health.js';",
-          [
-            'const healthRouter = createRouter();',
-            "healthRouter.get('/', (ctx) => { ctx.json({ status: 'ok' }); });",
-          ].join('\n')
-        );
-      writeFiles(projectDir, new Map([['src/index.ts', entrySource]]));
-
       const child = spawn(
         process.execPath,
-        ['--experimental-strip-types', join(projectDir, 'src', 'index.ts')],
-        { cwd: projectDir, stdio: ['ignore', 'pipe', 'pipe'] }
+        ['--import', SWC_LOADER, join(projectDir, 'src', 'index.ts')],
+        { cwd: projectDir, env: { ...process.env, PORT: String(port) }, stdio: ['ignore', 'pipe', 'pipe'] }
       );
       let stderrOutput = '';
       child.stderr?.on('data', (chunk: Buffer) => {

--- a/packages/create-nextrush/src/__tests__/generator.test.ts
+++ b/packages/create-nextrush/src/__tests__/generator.test.ts
@@ -108,6 +108,44 @@ describe('generateProject', () => {
       expect(files.has('src/routes/health.ts')).toBe(true);
     });
 
+    it('generates a todos CRUD feature with a pure data store', () => {
+      const files = generateProject(createOptions({ style: 'functional' }));
+      expect(files.has('src/routes/todos.ts')).toBe(true);
+      expect(files.has('src/routes/todos-data.ts')).toBe(true);
+      expect(files.has('src/routes/__tests__/todos-data.test.ts')).toBe(true);
+    });
+
+    it('mounts the todos router in the entrypoint', () => {
+      const files = generateProject(createOptions({ style: 'functional' }));
+      const entry = files.get('src/index.ts')!;
+      expect(entry).toContain("import { todosRouter } from './routes/todos.js';");
+      expect(entry).toContain("app.route('/todos', todosRouter);");
+    });
+
+    it('uses route params, query, body, and response codes in the todos feature', () => {
+      const files = generateProject(createOptions({ style: 'functional' }));
+      const todos = files.get('src/routes/todos.ts')!;
+      expect(todos).toContain("todosRouter.get('/',");
+      expect(todos).toContain("todosRouter.get('/:id',");
+      expect(todos).toContain("todosRouter.post('/',");
+      expect(todos).toContain("todosRouter.delete('/:id',");
+      expect(todos).toContain('ctx.params.id');
+      expect(todos).toContain('ctx.query.status');
+      expect(todos).toContain('ctx.body');
+      expect(todos).toContain('ctx.status = 201');
+      expect(todos).toContain('ctx.status = 204');
+      expect(todos).toContain('ctx.throw(404');
+      expect(todos).toContain('ctx.throw(400');
+    });
+
+    it('keeps todos state behind a pure store factory (no global mutable state)', () => {
+      const files = generateProject(createOptions({ style: 'functional' }));
+      const data = files.get('src/routes/todos-data.ts')!;
+      expect(data).toContain('export function createTodoStore()');
+      expect(data).not.toContain('export const todos');
+      expect(data).not.toContain('class TodoStore');
+    });
+
     it('uses createApp, createRouter, listen imports', () => {
       const files = generateProject(createOptions({ style: 'functional' }));
       const entry = files.get('src/index.ts')!;
@@ -440,8 +478,9 @@ describe('generateProject', () => {
     it('functional minimal generates correct number of files', () => {
       const files = generateProject(createOptions({ style: 'functional', middleware: 'minimal' }));
       // tsconfig, package.json, README, .gitignore, env.d.ts, src/index.ts,
-      // routes/health.ts, routes/health-status.ts, routes/__tests__/health-status.test.ts
-      expect(files.size).toBe(9);
+      // routes/health.ts, routes/health-status.ts, routes/todos.ts, routes/todos-data.ts,
+      // routes/__tests__/health-status.test.ts, routes/__tests__/todos-data.test.ts
+      expect(files.size).toBe(12);
     });
 
     it('class-based generates correct number of files', () => {

--- a/packages/create-nextrush/src/__tests__/generator.test.ts
+++ b/packages/create-nextrush/src/__tests__/generator.test.ts
@@ -180,11 +180,17 @@ describe('generateProject', () => {
   });
 
   describe('class-based style', () => {
-    it('generates controller and service files', () => {
+    it('generates feature-module, controller, and service files', () => {
       const files = generateProject(createOptions({ style: 'class-based' }));
       expect(files.has('src/index.ts')).toBe(true);
-      expect(files.has('src/controllers/health.controller.ts')).toBe(true);
-      expect(files.has('src/services/app.service.ts')).toBe(true);
+      expect(files.has('src/app.module.ts')).toBe(true);
+      expect(files.has('src/modules/health/health.module.ts')).toBe(true);
+      expect(files.has('src/modules/health/health.controller.ts')).toBe(true);
+      expect(files.has('src/modules/health/health.service.ts')).toBe(true);
+      expect(files.has('src/modules/todos/todos.module.ts')).toBe(true);
+      expect(files.has('src/modules/todos/todos.controller.ts')).toBe(true);
+      expect(files.has('src/modules/todos/todos.service.ts')).toBe(true);
+      expect(files.has('src/modules/todos/todos.repository.ts')).toBe(true);
     });
 
     it('does not manually import reflect-metadata (auto-imported by nextrush)', () => {
@@ -193,14 +199,25 @@ describe('generateProject', () => {
       expect(entry).not.toContain("import 'reflect-metadata'");
     });
 
-    it('uses awaited registerControllers with runtime-safe discovery config', () => {
+    it('wires the root module with registerModule instead of filesystem discovery', () => {
       const files = generateProject(createOptions({ style: 'class-based' }));
       const entry = files.get('src/index.ts')!;
-      expect(entry).toContain('await registerControllers(');
-      expect(entry).toContain('root: CONTROLLERS_ROOT');
-      expect(entry).toContain('include: CONTROLLERS_INCLUDE');
-      expect(entry).toContain('strict: true');
-      expect(entry).toContain("const CONTROLLERS_ROOT = IS_DIST_RUNTIME ? './dist/controllers' : './src/controllers';");
+      expect(entry).toContain("import { registerModule } from 'nextrush/class';");
+      expect(entry).toContain("import { AppModule } from './app.module.js';");
+      expect(entry).toContain('await registerModule(app, AppModule');
+      expect(entry).not.toContain('registerControllers');
+      expect(entry).not.toContain('CONTROLLERS_ROOT');
+      expect(entry).not.toContain('IS_DIST_RUNTIME');
+    });
+
+    it('declares feature modules in the root AppModule via imports', () => {
+      const files = generateProject(createOptions({ style: 'class-based' }));
+      const appModule = files.get('src/app.module.ts')!;
+      expect(appModule).toContain("@Module({");
+      expect(appModule).toContain('imports: [HealthModule, TodosModule]');
+      expect(appModule).toContain("import { HealthModule } from './modules/health/health.module.js';");
+      expect(appModule).toContain("import { TodosModule } from './modules/todos/todos.module.js';");
+      expect(appModule).toContain('export class AppModule');
     });
 
     it('uses simple PORT declaration in class-based entrypoint', () => {
@@ -212,22 +229,47 @@ describe('generateProject', () => {
 
     it('uses @Controller and @Get decorators', () => {
       const files = generateProject(createOptions({ style: 'class-based' }));
-      const controller = files.get('src/controllers/health.controller.ts')!;
+      const controller = files.get('src/modules/health/health.controller.ts')!;
       expect(controller).toContain('@Controller');
       expect(controller).toContain('@Get');
     });
 
     it('uses @Service decorator', () => {
       const files = generateProject(createOptions({ style: 'class-based' }));
-      const service = files.get('src/services/app.service.ts')!;
+      const service = files.get('src/modules/health/health.service.ts')!;
       expect(service).toContain('@Service');
     });
 
-    it('uses process.uptime() in app service', () => {
+    it('uses process.uptime() in health service', () => {
       const files = generateProject(createOptions({ style: 'class-based' }));
-      const service = files.get('src/services/app.service.ts')!;
+      const service = files.get('src/modules/health/health.service.ts')!;
       expect(service).toContain('process.uptime()');
       expect(service).not.toContain('getUptimeSeconds');
+    });
+
+    it('uses full CRUD decorator surface in the todos feature', () => {
+      const files = generateProject(createOptions({ style: 'class-based' }));
+      const controller = files.get('src/modules/todos/todos.controller.ts')!;
+      expect(controller).toContain('@Controller(\'/todos\')');
+      expect(controller).toContain('@Get()');
+      expect(controller).toContain('@Get(\':id\')');
+      expect(controller).toContain('@Post()');
+      expect(controller).toContain('@Delete(\':id\')');
+      expect(controller).toContain('@Param(\'id\')');
+      expect(controller).toContain('@Body()');
+      expect(controller).toContain('@Query(\'status\')');
+      expect(controller).toContain('@HttpCode(201)');
+      expect(controller).toContain('@HttpCode(204)');
+    });
+
+    it('uses @Repository and HttpError in the todos feature', () => {
+      const files = generateProject(createOptions({ style: 'class-based' }));
+      const repository = files.get('src/modules/todos/todos.repository.ts')!;
+      expect(repository).toContain('@Repository()');
+      const service = files.get('src/modules/todos/todos.service.ts')!;
+      expect(service).toContain("import { HttpError } from 'nextrush';");
+      expect(service).toContain("import { Service } from 'nextrush/class';");
+      expect(service).toContain('new HttpError(404');
     });
 
     it('includes reflect-metadata in dependencies', () => {
@@ -404,9 +446,11 @@ describe('generateProject', () => {
 
     it('class-based generates correct number of files', () => {
       const files = generateProject(createOptions({ style: 'class-based', middleware: 'minimal' }));
-      // tsconfig, package.json, README, .gitignore, env.d.ts, src/index.ts,
-      // health.controller.ts, app.service.ts, services/__tests__/app.service.test.ts
-      expect(files.size).toBe(9);
+      // tsconfig, package.json, README, .gitignore, env.d.ts, src/index.ts, src/app.module.ts,
+      // modules/health/{health.module,health.controller,health.service}.ts,
+      // modules/todos/{todos.module,todos.controller,todos.service,todos.repository}.ts,
+      // modules/todos/__tests__/{todos.service,todos.controller}.test.ts
+      expect(files.size).toBe(16);
     });
 
     it('full generates correct number of files', () => {

--- a/packages/create-nextrush/src/__tests__/integration.test.ts
+++ b/packages/create-nextrush/src/__tests__/integration.test.ts
@@ -82,8 +82,9 @@ describe('integration: file writing', () => {
 
     writeFiles(testDir, files);
 
-    expect(existsSync(join(testDir, 'src/controllers/health.controller.ts'))).toBe(true);
-    expect(existsSync(join(testDir, 'src/services/app.service.ts'))).toBe(true);
+    expect(existsSync(join(testDir, 'src/modules/health/health.controller.ts'))).toBe(true);
+    expect(existsSync(join(testDir, 'src/modules/todos/todos.service.ts'))).toBe(true);
+    expect(existsSync(join(testDir, 'src/app.module.ts'))).toBe(true);
   });
 
   it('creates all directories for full style', () => {

--- a/packages/create-nextrush/src/__tests__/integration.test.ts
+++ b/packages/create-nextrush/src/__tests__/integration.test.ts
@@ -50,6 +50,8 @@ describe('integration: file writing', () => {
     expect(existsSync(join(testDir, '.gitignore'))).toBe(true);
     expect(existsSync(join(testDir, 'src/index.ts'))).toBe(true);
     expect(existsSync(join(testDir, 'src/routes/health.ts'))).toBe(true);
+    expect(existsSync(join(testDir, 'src/routes/todos.ts'))).toBe(true);
+    expect(existsSync(join(testDir, 'src/routes/todos-data.ts'))).toBe(true);
     expect(existsSync(join(testDir, 'src/env.d.ts'))).toBe(true);
   });
 

--- a/packages/create-nextrush/src/templates/class-based.ts
+++ b/packages/create-nextrush/src/templates/class-based.ts
@@ -1,19 +1,28 @@
 import { MIDDLEWARE_IMPORTS, MIDDLEWARE_SETUP } from '../constants.js';
 import type { FileMap, ProjectOptions } from '../types.js';
-import {
-  getControllerDiscoveryHelpers,
-  getPortDeclaration,
-  getRuntimeEntrypointImports,
-} from './shared.js';
+import { getPortDeclaration, getRuntimeEntrypointImports } from './shared.js';
 
-/** Generates a class-based (decorators + DI) NextRush project. */
+/**
+ * Generates a class-based (decorators + DI + modules) NextRush project.
+ *
+ * Layout: feature modules co-located under `src/modules/<feature>/`. The root
+ * `AppModule` composes feature modules through `@Module({ imports })` — the same
+ * composition pattern `registerModule` resolves at boot (nesting, dedupe, cycles).
+ */
 export function generateClassBased(options: ProjectOptions): FileMap {
   const files: FileMap = new Map();
 
   files.set('src/index.ts', generateEntrypoint(options));
-  files.set('src/controllers/health.controller.ts', generateHealthController());
-  files.set('src/services/app.service.ts', generateAppService());
-  files.set('src/services/__tests__/app.service.test.ts', generateAppServiceTest());
+  files.set('src/app.module.ts', generateAppModule());
+  files.set('src/modules/health/health.module.ts', generateHealthModule());
+  files.set('src/modules/health/health.controller.ts', generateHealthController());
+  files.set('src/modules/health/health.service.ts', generateHealthService());
+  files.set('src/modules/todos/todos.module.ts', generateTodosModule());
+  files.set('src/modules/todos/todos.controller.ts', generateTodosController());
+  files.set('src/modules/todos/todos.service.ts', generateTodosService());
+  files.set('src/modules/todos/todos.repository.ts', generateTodosRepository());
+  files.set('src/modules/todos/__tests__/todos.service.test.ts', generateTodosServiceTest());
+  files.set('src/modules/todos/__tests__/todos.controller.test.ts', generateTodosControllerTest());
 
   return files;
 }
@@ -22,12 +31,12 @@ function generateEntrypoint(options: ProjectOptions): string {
   const middlewareImports = MIDDLEWARE_IMPORTS[options.middleware];
   const middlewareSetup = MIDDLEWARE_SETUP[options.middleware];
   const portDecl = getPortDeclaration(options.runtime);
-  const controllerDiscoveryHelpers = getControllerDiscoveryHelpers();
 
   const lines: string[] = [];
 
   lines.push(...getRuntimeEntrypointImports(options.runtime, 'listen'));
-  lines.push("import { registerControllers } from 'nextrush/class';");
+  lines.push("import { registerModule } from 'nextrush/class';");
+  lines.push("import { AppModule } from './app.module.js';");
 
   if (middlewareImports) {
     lines.push(middlewareImports);
@@ -37,7 +46,6 @@ function generateEntrypoint(options: ProjectOptions): string {
   lines.push('const router = createRouter();');
   lines.push('const app = createApp({ router });');
   lines.push(portDecl);
-  lines.push(controllerDiscoveryHelpers.trimEnd());
   lines.push('');
 
   if (middlewareSetup) {
@@ -46,13 +54,8 @@ function generateEntrypoint(options: ProjectOptions): string {
     lines.push('');
   }
 
-  lines.push('// Auto-discover controllers');
-  lines.push('await registerControllers(app, {');
-  lines.push('  root: CONTROLLERS_ROOT,');
-  lines.push('  include: CONTROLLERS_INCLUDE,');
-  lines.push("  prefix: '/api',");
-  lines.push('  strict: true,');
-  lines.push('});');
+  lines.push('// Wire the root module — registers the whole module graph in one call');
+  lines.push("await registerModule(app, AppModule, { prefix: '/api' });");
   lines.push('');
   lines.push('await listen(app, PORT);');
   lines.push('');
@@ -60,27 +63,54 @@ function generateEntrypoint(options: ProjectOptions): string {
   return lines.join('\n');
 }
 
+function generateAppModule(): string {
+  return `import { Module } from 'nextrush/class';
+
+import { HealthModule } from './modules/health/health.module.js';
+import { TodosModule } from './modules/todos/todos.module.js';
+
+@Module({
+  imports: [HealthModule, TodosModule],
+})
+export class AppModule {}
+`;
+}
+
+function generateHealthModule(): string {
+  return `import { Module } from 'nextrush/class';
+
+import { HealthController } from './health.controller.js';
+import { HealthService } from './health.service.js';
+
+@Module({
+  controllers: [HealthController],
+  providers: [HealthService],
+})
+export class HealthModule {}
+`;
+}
+
 function generateHealthController(): string {
   return `import { Controller, Get } from 'nextrush/class';
-import { AppService } from '../services/app.service.js';
+import { HealthService } from './health.service.js';
 
 @Controller('/health')
 export class HealthController {
-  constructor(private readonly appService: AppService) {}
+  constructor(private readonly health: HealthService) {}
 
   @Get()
   check() {
-    return this.appService.getHealth();
+    return this.health.getHealth();
   }
 }
 `;
 }
 
-function generateAppService(): string {
+function generateHealthService(): string {
   return `import { Service } from 'nextrush/class';
 
 @Service()
-export class AppService {
+export class HealthService {
   getHealth() {
     return {
       status: 'ok',
@@ -92,19 +122,191 @@ export class AppService {
 `;
 }
 
-function generateAppServiceTest(): string {
+function generateTodosModule(): string {
+  return `import { Module } from 'nextrush/class';
+
+import { TodosController } from './todos.controller.js';
+import { TodosRepository } from './todos.repository.js';
+import { TodosService } from './todos.service.js';
+
+@Module({
+  controllers: [TodosController],
+  providers: [TodosService, TodosRepository],
+})
+export class TodosModule {}
+`;
+}
+
+function generateTodosController(): string {
+  return `import { Body, Controller, Delete, Get, HttpCode, Param, Post, Query } from 'nextrush/class';
+import type { Todo } from './todos.repository.js';
+import type { CreateTodoInput } from './todos.service.js';
+import { TodosService } from './todos.service.js';
+
+@Controller('/todos')
+export class TodosController {
+  constructor(private readonly todos: TodosService) {}
+
+  @Get()
+  list(@Query('status') status?: string): Todo[] {
+    return this.todos.list(status);
+  }
+
+  @Get(':id')
+  get(@Param('id') id: string): Todo {
+    return this.todos.get(id);
+  }
+
+  @Post()
+  @HttpCode(201)
+  create(@Body() input: CreateTodoInput): Todo {
+    return this.todos.create(input);
+  }
+
+  @Delete(':id')
+  @HttpCode(204)
+  remove(@Param('id') id: string): void {
+    this.todos.remove(id);
+  }
+}
+`;
+}
+
+function generateTodosService(): string {
+  return `import { HttpError } from 'nextrush';
+import { Service } from 'nextrush/class';
+import { TodosRepository, type Todo } from './todos.repository.js';
+
+export interface CreateTodoInput {
+  title: string;
+  completed?: boolean;
+}
+
+@Service()
+export class TodosService {
+  constructor(private readonly repository: TodosRepository) {}
+
+  list(status?: string): Todo[] {
+    const todos = this.repository.findAll();
+    if (!status) return todos;
+    const completed = status === 'completed';
+    return todos.filter((todo) => todo.completed === completed);
+  }
+
+  get(id: string): Todo {
+    const todo = this.repository.findById(id);
+    if (!todo) throw new HttpError(404, 'Todo not found');
+    return todo;
+  }
+
+  create(input: CreateTodoInput): Todo {
+    const title = input.title.trim();
+    if (!title) throw new HttpError(400, 'Todo title is required');
+    return this.repository.create({ title, completed: input.completed ?? false });
+  }
+
+  remove(id: string): void {
+    if (!this.repository.delete(id)) throw new HttpError(404, 'Todo not found');
+  }
+}
+`;
+}
+
+function generateTodosRepository(): string {
+  return `import { Repository } from 'nextrush/class';
+
+export interface Todo {
+  id: string;
+  title: string;
+  completed: boolean;
+}
+
+@Repository()
+export class TodosRepository {
+  private readonly todos = new Map<string, Todo>();
+  private nextId = 1;
+
+  findAll(): Todo[] {
+    return [...this.todos.values()];
+  }
+
+  findById(id: string): Todo | undefined {
+    return this.todos.get(id);
+  }
+
+  create(input: Omit<Todo, 'id'>): Todo {
+    const todo: Todo = { ...input, id: String(this.nextId++) };
+    this.todos.set(todo.id, todo);
+    return todo;
+  }
+
+  delete(id: string): boolean {
+    return this.todos.delete(id);
+  }
+}
+`;
+}
+
+function generateTodosServiceTest(): string {
   return `import { describe, expect, it } from 'vitest';
 
-import { AppService } from '../app.service.js';
+import { TodosRepository } from '../todos.repository.js';
+import { TodosService } from '../todos.service.js';
 
-describe('AppService', () => {
-  it('reports status ok with a timestamp and uptime', () => {
-    const service = new AppService();
-    const result = service.getHealth();
+describe('TodosService', () => {
+  it('creates and lists todos', () => {
+    const service = new TodosService(new TodosRepository());
+    const created = service.create({ title: 'Ship NextRush', completed: false });
 
-    expect(result.status).toBe('ok');
-    expect(new Date(result.timestamp).toString()).not.toBe('Invalid Date');
-    expect(result.uptime).toBeGreaterThanOrEqual(0);
+    expect(service.list()).toContainEqual(created);
+  });
+
+  it('filters todos by completion status', () => {
+    const service = new TodosService(new TodosRepository());
+    service.create({ title: 'Done', completed: true });
+    service.create({ title: 'Open', completed: false });
+
+    expect(service.list('completed')).toHaveLength(1);
+    expect(service.list('completed')[0].title).toBe('Done');
+  });
+
+  it('throws a 404 for an unknown todo', () => {
+    const service = new TodosService(new TodosRepository());
+
+    expect(() => service.get('missing')).toThrow(/not found/i);
+  });
+
+  it('rejects an empty title', () => {
+    const service = new TodosService(new TodosRepository());
+
+    expect(() => service.create({ title: '   ' })).toThrow(/required/i);
+  });
+});
+`;
+}
+
+function generateTodosControllerTest(): string {
+  return `import { describe, expect, it } from 'vitest';
+
+import { TodosController } from '../todos.controller.js';
+import { TodosRepository } from '../todos.repository.js';
+import { TodosService } from '../todos.service.js';
+
+describe('TodosController', () => {
+  it('creates a todo and lists it', () => {
+    const controller = new TodosController(new TodosService(new TodosRepository()));
+    const created = controller.create({ title: 'Test todo', completed: false });
+
+    expect(controller.list()).toHaveLength(1);
+    expect(controller.get(created.id)).toEqual(created);
+  });
+
+  it('deletes a todo by id', () => {
+    const controller = new TodosController(new TodosService(new TodosRepository()));
+    const created = controller.create({ title: 'Remove me', completed: false });
+
+    expect(() => controller.remove(created.id)).not.toThrow();
+    expect(controller.list()).toHaveLength(0);
   });
 });
 `;

--- a/packages/create-nextrush/src/templates/functional.ts
+++ b/packages/create-nextrush/src/templates/functional.ts
@@ -5,14 +5,22 @@ import {
   getRuntimeEntrypointImports,
 } from './shared.js';
 
-/** Generates a functional-style NextRush project. */
+/**
+ * Generates a functional-style NextRush project — route handlers + pure helper
+ * functions, no classes or DI. Two features teach the idioms: a minimal health
+ * check and a full todos CRUD (params, query, body, response codes, error paths)
+ * backed by a pure, unit-testable in-memory store.
+ */
 export function generateFunctional(options: ProjectOptions): FileMap {
   const files: FileMap = new Map();
 
   files.set('src/index.ts', generateEntrypoint(options));
   files.set('src/routes/health.ts', generateHealthRoute());
   files.set('src/routes/health-status.ts', generateHealthStatus());
+  files.set('src/routes/todos.ts', generateTodosRoute());
+  files.set('src/routes/todos-data.ts', generateTodosData());
   files.set('src/routes/__tests__/health-status.test.ts', generateHealthStatusTest());
+  files.set('src/routes/__tests__/todos-data.test.ts', generateTodosDataTest());
 
   return files;
 }
@@ -31,6 +39,7 @@ function generateEntrypoint(options: ProjectOptions): string {
   }
 
   lines.push("import { healthRouter } from './routes/health.js';");
+  lines.push("import { todosRouter } from './routes/todos.js';");
   lines.push('');
   lines.push('const router = createRouter();');
   lines.push('const app = createApp({ router });');
@@ -49,6 +58,7 @@ function generateEntrypoint(options: ProjectOptions): string {
   lines.push('});');
   lines.push('');
   lines.push("app.route('/health', healthRouter);");
+  lines.push("app.route('/todos', todosRouter);");
   lines.push('');
   lines.push('await listen(app, PORT);');
   lines.push('');
@@ -94,6 +104,138 @@ describe('getHealthStatus', () => {
     expect(result.status).toBe('ok');
     expect(new Date(result.timestamp).toString()).not.toBe('Invalid Date');
     expect(result.uptime).toBeGreaterThanOrEqual(0);
+  });
+});
+`;
+}
+
+function generateTodosRoute(): string {
+  return `import { createRouter } from 'nextrush';
+
+import { createTodoStore, type CreateTodoInput } from './todos-data.js';
+
+const todoStore = createTodoStore();
+
+export const todosRouter = createRouter();
+
+todosRouter.get('/', (ctx) => {
+  const status = typeof ctx.query.status === 'string' ? ctx.query.status : undefined;
+  ctx.json(todoStore.list(status));
+});
+
+todosRouter.get('/:id', (ctx) => {
+  const todo = todoStore.get(ctx.params.id);
+  if (!todo) ctx.throw(404, 'Todo not found');
+  ctx.json(todo);
+});
+
+todosRouter.post('/', (ctx) => {
+  const input = (ctx.body ?? {}) as Partial<CreateTodoInput>;
+  try {
+    const todo = todoStore.create({ title: input.title ?? '', completed: input.completed });
+    ctx.status = 201;
+    ctx.json(todo);
+  } catch (err) {
+    ctx.throw(400, err instanceof Error ? err.message : 'Invalid todo');
+  }
+});
+
+todosRouter.delete('/:id', (ctx) => {
+  if (!todoStore.remove(ctx.params.id)) ctx.throw(404, 'Todo not found');
+  ctx.status = 204;
+});
+`;
+}
+
+function generateTodosData(): string {
+  return `export interface Todo {
+  id: string;
+  title: string;
+  completed: boolean;
+}
+
+export interface CreateTodoInput {
+  title: string;
+  completed?: boolean;
+}
+
+/** In-memory todo store. A factory returning a closure keeps state per-instance and
+ * keeps every operation a pure function — unit-testable without an HTTP server. */
+export function createTodoStore() {
+  const todos = new Map<string, Todo>();
+  let nextId = 1;
+
+  return {
+    list(status?: string): Todo[] {
+      const all = [...todos.values()];
+      if (status !== 'completed' && status !== 'pending') return all;
+      const completed = status === 'completed';
+      return all.filter((todo) => todo.completed === completed);
+    },
+
+    get(id: string): Todo | undefined {
+      return todos.get(id);
+    },
+
+    create(input: CreateTodoInput): Todo {
+      const title = input.title.trim();
+      if (!title) throw new Error('Todo title is required');
+      const todo: Todo = { id: String(nextId++), title, completed: input.completed ?? false };
+      todos.set(todo.id, todo);
+      return todo;
+    },
+
+    remove(id: string): boolean {
+      return todos.delete(id);
+    },
+  };
+}
+
+export type TodoStore = ReturnType<typeof createTodoStore>;
+`;
+}
+
+function generateTodosDataTest(): string {
+  return `import { describe, expect, it } from 'vitest';
+
+import { createTodoStore } from '../todos-data.js';
+
+describe('createTodoStore', () => {
+  it('creates and lists todos', () => {
+    const store = createTodoStore();
+    const created = store.create({ title: 'Ship NextRush', completed: false });
+
+    expect(store.list()).toContainEqual(created);
+  });
+
+  it('filters todos by completion status', () => {
+    const store = createTodoStore();
+    store.create({ title: 'Done', completed: true });
+    store.create({ title: 'Open', completed: false });
+
+    expect(store.list('completed')).toHaveLength(1);
+    expect(store.list('completed')[0].title).toBe('Done');
+  });
+
+  it('returns undefined for an unknown todo', () => {
+    const store = createTodoStore();
+
+    expect(store.get('missing')).toBeUndefined();
+  });
+
+  it('rejects an empty title', () => {
+    const store = createTodoStore();
+
+    expect(() => store.create({ title: '   ' })).toThrow(/required/i);
+  });
+
+  it('removes a todo and reports whether it existed', () => {
+    const store = createTodoStore();
+    const created = store.create({ title: 'Remove me', completed: false });
+
+    expect(store.remove(created.id)).toBe(true);
+    expect(store.remove(created.id)).toBe(false);
+    expect(store.list()).toHaveLength(0);
   });
 });
 `;

--- a/packages/dev/README.md
+++ b/packages/dev/README.md
@@ -136,7 +136,7 @@ nextrush build --target es2020
 
 ### `nextrush generate` - Code Generator
 
-Generate controllers, services, middleware, guards, and routes.
+Generate modules, controllers, services, middleware, guards, and routes.
 
 ```bash
 # Generate a controller class
@@ -146,43 +146,52 @@ nextrush generate controller user
 nextrush g controller user
 
 # Generate all types
-nextrush g s user-profile        # Service
-nextrush g mw logger             # Middleware
-nextrush g guard auth            # Guard
-nextrush g r products            # Route
+nextrush g m todos              # Module
+nextrush g s user-profile       # Service
+nextrush g mw logger            # Middleware
+nextrush g guard auth           # Guard
+nextrush g r products           # Route
 ```
 
 **Types:**
 
-| Type         | Alias | Output Path                            | Style       |
-| ------------ | ----- | -------------------------------------- | ----------- |
-| `controller` | `c`   | `src/controllers/<name>.controller.ts` | Class-based |
-| `service`    | `s`   | `src/services/<name>.service.ts`       | Class-based |
-| `middleware` | `mw`  | `src/middleware/<name>.ts`             | Functional  |
-| `guard`      | `g`   | `src/guards/<name>.guard.ts`           | Functional  |
-| `route`      | `r`   | `src/routes/<name>.ts`                 | Functional  |
+| Type         | Alias | Default Output Path                        | Module project (`src/modules/` exists) | Style       |
+| ------------ | ----- | ------------------------------------------ | -------------------------------------- | ----------- |
+| `module`     | `m`   | `src/modules/<name>/<name>.module.ts`      | `src/modules/<name>/<name>.module.ts`  | Class-based |
+| `controller` | `c`   | `src/controllers/<name>.controller.ts`     | `src/modules/<name>/<name>.controller.ts` | Class-based |
+| `service`    | `s`   | `src/services/<name>.service.ts`           | `src/modules/<name>/<name>.service.ts` | Class-based |
+| `middleware` | `mw`  | `src/middleware/<name>.ts`                 | `src/middleware/<name>.ts`             | Functional  |
+| `guard`      | `g`   | `src/guards/<name>.guard.ts`               | `src/guards/<name>.guard.ts`           | Functional  |
+| `route`      | `r`   | `src/routes/<name>.ts`                     | `src/routes/<name>.ts`                 | Functional  |
+
+Controllers and services co-locate into a feature module (`src/modules/<name>/`) when the
+project has a `src/modules/` directory (the layout `create-nextrush`'s class-based template
+emits); module-less projects keep the flat directories.
 
 **Generated Controller Example:**
 
 ```typescript
-// nextrush g controller user -> src/controllers/user.controller.ts
-import { Controller, Get, Post, Body, Param } from 'nextrush/class';
+// nextrush g controller user -> src/modules/user/user.controller.ts (module project)
+import { Body, Controller, Get, Param, Post } from 'nextrush/class';
+import { UserService } from './user.service.js';
 
 @Controller('/user')
 export class UserController {
+  constructor(private readonly userService: UserService) {}
+
   @Get()
-  async findAll() {
-    return [];
+  findAll() {
+    return this.userService.findAll();
   }
 
   @Get('/:id')
-  async findOne(@Param('id') id: string) {
-    return { id };
+  findOne(@Param('id') id: string) {
+    return this.userService.findOne(id);
   }
 
   @Post()
-  async create(@Body() data: unknown) {
-    return data;
+  create(@Body() data: unknown) {
+    return this.userService.create(data);
   }
 }
 ```
@@ -190,20 +199,23 @@ export class UserController {
 **Generated Service Example:**
 
 ```typescript
-// nextrush g s order -> src/services/order.service.ts
+// nextrush g s order -> src/modules/order/order.service.ts (module project)
+import { HttpError } from 'nextrush';
 import { Service } from 'nextrush/class';
 
 @Service()
 export class OrderService {
-  async findAll() {
+  findAll() {
     return [];
   }
 
-  async findOne(id: string) {
+  findOne(id: string) {
+    if (!id) throw new HttpError(404, 'Not found');
     return { id };
   }
 
-  async create(data: unknown) {
+  create(data: unknown) {
+    if (!data || typeof data !== 'object') throw new HttpError(400, 'Invalid input');
     return data;
   }
 }

--- a/packages/dev/src/__tests__/generators/generate.test.ts
+++ b/packages/dev/src/__tests__/generators/generate.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { mkdir, mkdtemp, readFile, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
@@ -6,6 +6,7 @@ import {
   buildFilePath,
   generate,
   resolveGeneratorType,
+  resolveOutputDirectory,
   validateName,
 } from '../../generators/generate.js';
 
@@ -18,11 +19,13 @@ describe('resolveGeneratorType', () => {
     expect(resolveGeneratorType('middleware')).toBe('middleware');
     expect(resolveGeneratorType('guard')).toBe('guard');
     expect(resolveGeneratorType('route')).toBe('route');
+    expect(resolveGeneratorType('module')).toBe('module');
   });
 
   it('resolves aliases', () => {
     expect(resolveGeneratorType('c')).toBe('controller');
     expect(resolveGeneratorType('s')).toBe('service');
+    expect(resolveGeneratorType('m')).toBe('module');
     expect(resolveGeneratorType('mw')).toBe('middleware');
     expect(resolveGeneratorType('g')).toBe('guard');
     expect(resolveGeneratorType('r')).toBe('route');
@@ -32,6 +35,7 @@ describe('resolveGeneratorType', () => {
     expect(resolveGeneratorType('Controller')).toBe('controller');
     expect(resolveGeneratorType('SERVICE')).toBe('service');
     expect(resolveGeneratorType('GUARD')).toBe('guard');
+    expect(resolveGeneratorType('MODULE')).toBe('module');
   });
 
   it('returns undefined for unknown types', () => {
@@ -117,9 +121,57 @@ describe('buildFilePath', () => {
     expect(path).toBe('/project/src/routes/products.ts');
   });
 
+  it('builds module file path', () => {
+    const path = buildFilePath('/project', 'module', 'todos');
+    expect(path).toBe('/project/src/modules/todos.module.ts');
+  });
+
   it('handles kebab-case names', () => {
     const path = buildFilePath('/project', 'controller', 'user-profile');
     expect(path).toBe('/project/src/controllers/user-profile.controller.ts');
+  });
+});
+
+// ─── resolveOutputDirectory (module-aware placement) ────────────────────
+
+describe('resolveOutputDirectory', () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'nextrush-resolve-'));
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it('uses flat src/controllers when the project has no modules dir', async () => {
+    const dir = await resolveOutputDirectory(tempDir, 'controller', 'user');
+    expect(dir).toBe('src/controllers');
+  });
+
+  it('co-locates controllers into src/modules/<name> when src/modules exists', async () => {
+    await mkdir(join(tempDir, 'src', 'modules'), { recursive: true });
+    const dir = await resolveOutputDirectory(tempDir, 'controller', 'user');
+    expect(dir).toBe('src/modules/user');
+  });
+
+  it('co-locates services into src/modules/<name> when src/modules exists', async () => {
+    await mkdir(join(tempDir, 'src', 'modules'), { recursive: true });
+    const dir = await resolveOutputDirectory(tempDir, 'service', 'user');
+    expect(dir).toBe('src/modules/user');
+  });
+
+  it('keeps non-feature types on their flat directories even with modules present', async () => {
+    await mkdir(join(tempDir, 'src', 'modules'), { recursive: true });
+    expect(await resolveOutputDirectory(tempDir, 'route', 'products')).toBe('src/routes');
+    expect(await resolveOutputDirectory(tempDir, 'middleware', 'logger')).toBe('src/middleware');
+    expect(await resolveOutputDirectory(tempDir, 'guard', 'auth')).toBe('src/guards');
+  });
+
+  it('places a module in its own feature directory even without src/modules yet', async () => {
+    const dir = await resolveOutputDirectory(tempDir, 'module', 'todos');
+    expect(dir).toBe('src/modules/todos');
   });
 });
 
@@ -176,7 +228,33 @@ describe('generate (filesystem)', () => {
 
     const content = await readFile(filePath, 'utf-8');
     expect(content).toContain('createRouter');
-    expect(content).toContain('export default router');
+    expect(content).toContain('export const productsRouter = createRouter()');
+    expect(content).not.toContain('export default');
+  });
+
+  it('creates a module file', async () => {
+    const filePath = await generate('module', 'todos', tempDir);
+    expect(filePath).toContain('src/modules/todos/todos.module.ts');
+
+    const content = await readFile(filePath, 'utf-8');
+    expect(content).toContain('export class TodosModule');
+    expect(content).toContain('@Module({');
+  });
+
+  it('co-locates a controller into its feature module when src/modules exists', async () => {
+    await mkdir(join(tempDir, 'src', 'modules'), { recursive: true });
+    const filePath = await generate('controller', 'user', tempDir);
+    expect(filePath).toContain('src/modules/user/user.controller.ts');
+
+    const content = await readFile(filePath, 'utf-8');
+    expect(content).toContain('export class UserController');
+    expect(content).toContain("import { UserService } from './user.service.js'");
+  });
+
+  it('co-locates a service into its feature module when src/modules exists', async () => {
+    await mkdir(join(tempDir, 'src', 'modules'), { recursive: true });
+    const filePath = await generate('service', 'user', tempDir);
+    expect(filePath).toContain('src/modules/user/user.service.ts');
   });
 
   it('creates directories recursively', async () => {

--- a/packages/dev/src/__tests__/generators/templates.test.ts
+++ b/packages/dev/src/__tests__/generators/templates.test.ts
@@ -6,6 +6,7 @@ import {
   GENERATORS,
   guardTemplate,
   middlewareTemplate,
+  moduleTemplate,
   routeTemplate,
   serviceTemplate,
   toCamelCase,
@@ -58,7 +59,7 @@ describe('controllerTemplate', () => {
   it('imports class-based decorators from nextrush/class', () => {
     const output = controllerTemplate('user');
     expect(output).toContain(
-      "import { Controller, Get, Post, Body, Param } from 'nextrush/class'"
+      "import { Body, Controller, Get, Param, Post } from 'nextrush/class'"
     );
   });
 
@@ -79,9 +80,19 @@ describe('controllerTemplate', () => {
     expect(output).toContain('create');
   });
 
+  it('injects the matching service via constructor DI', () => {
+    const output = controllerTemplate('user');
+    expect(output).toContain("constructor(private readonly userService: UserService)");
+    expect(output).toContain("import { UserService } from './user.service.js'");
+    expect(output).toContain('this.userService.findAll()');
+    expect(output).toContain('this.userService.findOne(id)');
+    expect(output).toContain('this.userService.create(data)');
+  });
+
   it('uses PascalCase for multi-word names', () => {
     const output = controllerTemplate('order-item');
     expect(output).toContain('export class OrderItemController');
+    expect(output).toContain("constructor(private readonly orderItemService: OrderItemService)");
   });
 });
 
@@ -106,7 +117,8 @@ describe('serviceTemplate', () => {
   it('does not import Service from the bare nextrush root', () => {
     const output = serviceTemplate('user');
     // @Service is a DI decorator re-exported from 'nextrush/class', not the root.
-    expect(output).not.toContain("from 'nextrush'");
+    expect(output).not.toContain("Service } from 'nextrush'");
+    expect(output).toContain("import { Service } from 'nextrush/class'");
   });
 
   it('includes CRUD method stubs', () => {
@@ -114,6 +126,40 @@ describe('serviceTemplate', () => {
     expect(output).toContain('findAll');
     expect(output).toContain('findOne');
     expect(output).toContain('create');
+  });
+
+  it('uses HttpError for 404 and 400 paths (from the nextrush root)', () => {
+    const output = serviceTemplate('user');
+    expect(output).toContain("import { HttpError } from 'nextrush';");
+    expect(output).toContain("throw new HttpError(404, 'Not found')");
+    expect(output).toContain("throw new HttpError(400, 'Invalid input')");
+  });
+});
+
+// ─── Module Template ─────────────────────────────────────────────────────
+
+describe('moduleTemplate', () => {
+  it('generates a class with correct name', () => {
+    const output = moduleTemplate('todos');
+    expect(output).toContain('export class TodosModule');
+  });
+
+  it('uses @Module() decorator with controllers and providers', () => {
+    const output = moduleTemplate('todos');
+    expect(output).toContain('@Module({');
+    expect(output).toContain('controllers: [TodosController]');
+    expect(output).toContain('providers: [TodosService]');
+  });
+
+  it('imports the co-located controller and service', () => {
+    const output = moduleTemplate('todos');
+    expect(output).toContain("import { TodosController } from './todos.controller.js';");
+    expect(output).toContain("import { TodosService } from './todos.service.js';");
+  });
+
+  it('imports Module from nextrush/class', () => {
+    const output = moduleTemplate('todos');
+    expect(output).toContain("import { Module } from 'nextrush/class'");
   });
 });
 
@@ -179,17 +225,25 @@ describe('routeTemplate', () => {
     expect(output).toContain("import { createRouter } from 'nextrush'");
   });
 
-  it('creates a router and exports it as default', () => {
+  it('creates a named-export router (matches the functional template idiom)', () => {
     const output = routeTemplate('products');
-    expect(output).toContain('const router = createRouter()');
-    expect(output).toContain('export default router');
+    expect(output).toContain('export const productsRouter = createRouter()');
+    expect(output).not.toContain('export default');
   });
 
-  it('includes GET and POST routes', () => {
+  it('uses camelCase router name for multi-word names', () => {
+    const output = routeTemplate('order-item');
+    expect(output).toContain('export const orderItemRouter = createRouter()');
+  });
+
+  it('includes GET and POST routes with params, body, and status codes', () => {
     const output = routeTemplate('products');
-    expect(output).toContain("router.get('/'");
-    expect(output).toContain("router.get('/:id'");
-    expect(output).toContain("router.post('/'");
+    expect(output).toContain("productsRouter.get('/'");
+    expect(output).toContain("productsRouter.get('/:id'");
+    expect(output).toContain("productsRouter.post('/'");
+    expect(output).toContain('ctx.params.id');
+    expect(output).toContain('ctx.body');
+    expect(output).toContain('ctx.status = 201');
   });
 
   it('does not use class-based decorators', () => {
@@ -202,8 +256,15 @@ describe('routeTemplate', () => {
 // ─── Registry ────────────────────────────────────────────────────────────
 
 describe('GENERATOR_TYPES', () => {
-  it('contains all 5 types', () => {
-    expect(GENERATOR_TYPES).toEqual(['controller', 'service', 'middleware', 'guard', 'route']);
+  it('contains all 6 types', () => {
+    expect(GENERATOR_TYPES).toEqual([
+      'controller',
+      'service',
+      'middleware',
+      'guard',
+      'route',
+      'module',
+    ]);
   });
 });
 
@@ -211,6 +272,7 @@ describe('GENERATOR_ALIASES', () => {
   it('maps short aliases to types', () => {
     expect(GENERATOR_ALIASES['c']).toBe('controller');
     expect(GENERATOR_ALIASES['s']).toBe('service');
+    expect(GENERATOR_ALIASES['m']).toBe('module');
     expect(GENERATOR_ALIASES['mw']).toBe('middleware');
     expect(GENERATOR_ALIASES['g']).toBe('guard');
     expect(GENERATOR_ALIASES['r']).toBe('route');
@@ -251,5 +313,10 @@ describe('GENERATORS', () => {
   it('route writes to src/routes with .ts suffix', () => {
     expect(GENERATORS.route.directory).toBe('src/routes');
     expect(GENERATORS.route.suffix).toBe('.ts');
+  });
+
+  it('module writes to src/modules with .module.ts suffix', () => {
+    expect(GENERATORS.module.directory).toBe('src/modules');
+    expect(GENERATORS.module.suffix).toBe('.module.ts');
   });
 });

--- a/packages/dev/src/generators/generate.ts
+++ b/packages/dev/src/generators/generate.ts
@@ -43,11 +43,39 @@ export function validateName(name: string): string | undefined {
 }
 
 /**
- * Build the output file path for a generator.
+ * Build the output file path for a generator using its default (flat) directory.
+ * Module-aware placement is resolved separately by {@link resolveOutputDirectory}.
  */
 export function buildFilePath(cwd: string, type: GeneratorType, name: string): string {
   const config = GENERATORS[type];
   return joinPath(cwd, config.directory, `${name}${config.suffix}`);
+}
+
+/** Types that co-locate into a feature directory when the project uses modules. */
+const FEATURE_DIRECTORY_TYPES: readonly GeneratorType[] = ['controller', 'service'];
+
+/**
+ * Resolve the output directory for a generator, matching the scaffolded project
+ * structure:
+ *
+ * - `module` always lands in its own feature directory (`src/modules/<name>/`),
+ *   the shape `create-nextrush`'s class-based template emits.
+ * - `controller`/`service` in a class-based module project (a `src/modules/`
+ *   directory exists) land in `src/modules/<name>/` so they co-locate with the
+ *   feature's other files (module, tests).
+ * - Everything else (including module-less/full-style projects) uses the
+ *   generator's default flat directory (`src/controllers/`, `src/services/`, ...).
+ *
+ * @param cwd - Project root.
+ * @param type - Generator type.
+ * @param name - Scaffold name (kebab-case).
+ * @returns The output directory relative to `cwd`.
+ */
+export async function resolveOutputDirectory(cwd: string, type: GeneratorType, name: string): Promise<string> {
+  if (type === 'module' || (FEATURE_DIRECTORY_TYPES.includes(type) && (await exists(joinPath(cwd, 'src', 'modules'))))) {
+    return joinPath('src', 'modules', name);
+  }
+  return GENERATORS[type].directory;
 }
 
 /**
@@ -56,8 +84,9 @@ export function buildFilePath(cwd: string, type: GeneratorType, name: string): s
 export async function generate(type: GeneratorType, name: string, cwd?: string): Promise<string> {
   const root = cwd ?? getCwd();
   const config = GENERATORS[type];
-  const filePath = buildFilePath(root, type, name);
-  const dirPath = joinPath(root, config.directory);
+  const directory = await resolveOutputDirectory(root, type, name);
+  const filePath = joinPath(root, directory, `${name}${config.suffix}`);
+  const dirPath = joinPath(root, directory);
 
   // Check if file already exists
   if (await exists(filePath)) {
@@ -163,7 +192,7 @@ export async function generateCli(args: string[]): Promise<void> {
   if (!type) {
     error(`Unknown generator type: "${typeArg}"`);
     error(`Available types: ${GENERATOR_TYPES.join(', ')}`);
-    error(`Aliases: c (controller), s (service), mw (middleware), g (guard), r (route)`);
+    error(`Aliases: c (controller), s (service), m (module), mw (middleware), g (guard), r (route)`);
     exitProcess(1);
   }
 
@@ -200,6 +229,7 @@ Usage: nextrush generate <type> <name>
 Types:
   controller, c    Create a controller class (src/controllers/<name>.controller.ts)
   service, s       Create a service class    (src/services/<name>.service.ts)
+  module, m        Create a feature module    (src/modules/<name>/<name>.module.ts)
   middleware, mw   Create a middleware fn     (src/middleware/<name>.ts)
   guard, g         Create a guard fn          (src/guards/<name>.guard.ts)
   route, r         Create a route module      (src/routes/<name>.ts)
@@ -208,6 +238,7 @@ Types:
 Examples:
   nextrush g controller user       Create src/controllers/user.controller.ts
   nextrush g s user                Create src/services/user.service.ts
+  nextrush g m todos               Create src/modules/todos/todos.module.ts
   nextrush g mw logger             Create src/middleware/logger.ts
   nextrush g guard auth            Create src/guards/auth.guard.ts
   nextrush g r products            Create src/routes/products.ts

--- a/packages/dev/src/generators/templates.ts
+++ b/packages/dev/src/generators/templates.ts
@@ -35,23 +35,28 @@ export function toCamelCase(name: string): string {
 
 export function controllerTemplate(name: string): string {
   const className = `${toPascalCase(name)}Controller`;
-  return `import { Controller, Get, Post, Body, Param } from 'nextrush/class';
+  const serviceName = `${toPascalCase(name)}Service`;
+  const serviceRef = `${toCamelCase(name)}Service`;
+  return `import { Body, Controller, Get, Param, Post } from 'nextrush/class';
+import { ${serviceName} } from './${name}.service.js';
 
 @Controller('/${name}')
 export class ${className} {
+  constructor(private readonly ${serviceRef}: ${serviceName}) {}
+
   @Get()
-  async findAll() {
-    return [];
+  findAll() {
+    return this.${serviceRef}.findAll();
   }
 
   @Get('/:id')
-  async findOne(@Param('id') id: string) {
-    return { id };
+  findOne(@Param('id') id: string) {
+    return this.${serviceRef}.findOne(id);
   }
 
   @Post()
-  async create(@Body() data: unknown) {
-    return data;
+  create(@Body() data: unknown) {
+    return this.${serviceRef}.create(data);
   }
 }
 `;
@@ -61,22 +66,44 @@ export class ${className} {
 
 export function serviceTemplate(name: string): string {
   const className = `${toPascalCase(name)}Service`;
-  return `import { Service } from 'nextrush/class';
+  return `import { HttpError } from 'nextrush';
+import { Service } from 'nextrush/class';
 
 @Service()
 export class ${className} {
-  async findAll() {
+  findAll() {
     return [];
   }
 
-  async findOne(id: string) {
+  findOne(id: string) {
+    if (!id) throw new HttpError(404, 'Not found');
     return { id };
   }
 
-  async create(data: unknown) {
+  create(data: unknown) {
+    if (!data || typeof data !== 'object') throw new HttpError(400, 'Invalid input');
     return data;
   }
 }
+`;
+}
+
+// ─── Module (class-based feature module) ─────────────────────────────────
+
+export function moduleTemplate(name: string): string {
+  const className = `${toPascalCase(name)}Module`;
+  const controllerName = `${toPascalCase(name)}Controller`;
+  const serviceName = `${toPascalCase(name)}Service`;
+  return `import { Module } from 'nextrush/class';
+
+import { ${controllerName} } from './${name}.controller.js';
+import { ${serviceName} } from './${name}.service.js';
+
+@Module({
+  controllers: [${controllerName}],
+  providers: [${serviceName}],
+})
+export class ${className} {}
 `;
 }
 
@@ -112,30 +139,30 @@ export const ${fnName}: GuardFn = async (ctx) => {
 
 // ─── Route (functional) ─────────────────────────────────────────────────
 
-export function routeTemplate(_name: string): string {
+export function routeTemplate(name: string): string {
+  const routerName = `${toCamelCase(name)}Router`;
   return `import { createRouter } from 'nextrush';
 
-const router = createRouter();
+export const ${routerName} = createRouter();
 
-router.get('/', (ctx) => {
+${routerName}.get('/', (ctx) => {
   ctx.json([]);
 });
 
-router.get('/:id', (ctx) => {
+${routerName}.get('/:id', (ctx) => {
   ctx.json({ id: ctx.params.id });
 });
 
-router.post('/', (ctx) => {
+${routerName}.post('/', (ctx) => {
+  ctx.status = 201;
   ctx.json(ctx.body);
 });
-
-export default router;
 `;
 }
 
 // ─── Template Registry ──────────────────────────────────────────────────
 
-export type GeneratorType = 'controller' | 'service' | 'middleware' | 'guard' | 'route';
+export type GeneratorType = 'controller' | 'service' | 'middleware' | 'guard' | 'route' | 'module';
 
 export const GENERATOR_TYPES: readonly GeneratorType[] = [
   'controller',
@@ -143,6 +170,7 @@ export const GENERATOR_TYPES: readonly GeneratorType[] = [
   'middleware',
   'guard',
   'route',
+  'module',
 ];
 
 /** Short aliases for generator types */
@@ -152,6 +180,7 @@ export const GENERATOR_ALIASES: Record<string, GeneratorType> = {
   mw: 'middleware',
   g: 'guard',
   r: 'route',
+  m: 'module',
 };
 
 interface GeneratorConfig {
@@ -186,5 +215,10 @@ export const GENERATORS: Record<GeneratorType, GeneratorConfig> = {
     template: routeTemplate,
     directory: 'src/routes',
     suffix: '.ts',
+  },
+  module: {
+    template: moduleTemplate,
+    directory: 'src/modules',
+    suffix: '.module.ts',
   },
 };

--- a/packages/dev/tsconfig.json
+++ b/packages/dev/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "./dist",
+    "rootDir": "./src",
     "declaration": true,
     "declarationMap": true,
     "ignoreDeprecations": "6.0",


### PR DESCRIPTION
## Summary

Aligns the `create-nextrush` scaffolds and `@nextrush/dev` generators with a coherent, properly-structured developer experience — feature-module layouts, real CRUD teaching patterns, and DI-connected generator output.

## Changes

### create-nextrush — class-based template (`d0abf8c`)
- Feature modules under `src/modules/<feature>/` — root `AppModule` composes via `@Module({ imports })` (nested imports, dedupe, cycles handled by `registerModule`)
- Two feature modules teach complementary patterns:
  - `health/` — minimal controller + service with constructor DI
  - `todos/` — full CRUD (`@Get`/`@Post`/`@Delete` with `@Param`/`@Body`/`@Query`, `@HttpCode(201/204)`, `@Repository`, `HttpError` 400/404 paths) + unit tests

### create-nextrush — functional template (`c70019c`)
- Functional was health-only; added a todos CRUD feature:
  - `src/routes/todos.ts` — handlers using `ctx.params`/`ctx.query`/`ctx.body`/`ctx.status`/`ctx.throw`
  - `src/routes/todos-data.ts` — pure `createTodoStore()` factory (per-instance state, no global mutable state, unit-testable)
  - unit tests for the pure store

### @nextrush/dev — generator alignment (`570e6be`)
Generators did not follow the scaffold structure:
- `route` → named-export router (`export const productRouter`), matching the functional template's `app.route()` idiom (was `export default`)
- `controller` → constructor-DI injects the matching service (was a standalone stub)
- `service` → `HttpError` 400/404 pattern
- new `module` generator type → `src/modules/<name>/<name>.module.ts` (feature modules were impossible to scaffold)
- module-aware placement: with `src/modules/` present, controllers/services co-locate into `src/modules/<name>/`; module-less projects keep flat `src/controllers`/`src/services`
- fix `rootDir` in dev tsconfig for TS 6 typecheck

### Docs
- `create-nextrush` README + ARCHITECTURE synced to new structures
- `apps/website` generators.mdx + dev README synced to generator behavior

## Verification

- create-nextrush: 230/230 tests (incl. generated-example-test running generated vitest)
- @nextrush/dev: 289/289 tests
- Both packages typecheck + lint clean
- Boot-verified via real dev toolchain (swc-node/register): class-based + functional + full templates, plus a `nextrush g`-generated feature (module+controller+service) wired into `AppModule` — DI chain, CRUD, 400/404 all live
- Generated projects typecheck strict + `verbatimModuleSyntax`

## Changesets

- `create-nextrush` minor
- `@nextrush/dev` minor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added todos CRUD functionality to generated functional and class-based projects, including validation, filtering, and error handling.
  * Added feature-module scaffolding with health and todos modules, dependency injection, and unit tests.
  * Added a module generator with module-aware file placement and named route exports.
* **Documentation**
  * Updated generator, scaffold, README, and architecture documentation with new module and todos workflows.
* **Tests**
  * Expanded generator, integration, and runtime parity coverage for the new templates and module generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->